### PR TITLE
Fix compilation errors (Clang 16)

### DIFF
--- a/c_src/simdjson_nif.cpp
+++ b/c_src/simdjson_nif.cpp
@@ -80,8 +80,8 @@ static ERL_NIF_TERM make_term(ErlNifEnv* env, const dom::element& elm)
       memcpy(bin.data, str.data(), str.length());
       return enif_make_binary(env, &bin);
     }
-    case dom::element_type::INT64:      return enif_make_long(env, elm);
-    case dom::element_type::UINT64:     return enif_make_ulong(env, elm);
+    case dom::element_type::INT64:      return enif_make_long(env, int64_t(elm));
+    case dom::element_type::UINT64:     return enif_make_ulong(env, uint64_t(elm));
     case dom::element_type::DOUBLE:     return enif_make_double(env, elm);
     case dom::element_type::BOOL:       return elm.get<bool>() ? ATOM_TRUE : ATOM_FALSE;
     case dom::element_type::NULL_VALUE:


### PR DESCRIPTION
FIx compilation errors when using `Clang 16`.

```
make
rebar3 compile
===> Fetching rebar3_hex v7.0.6
===> Fetching hex_core v0.8.4
===> Fetching verl v1.1.1
===> Analyzing applications...
===> Compiling hex_core
===> Compiling verl
===> Compiling rebar3_hex
===> Verifying dependencies...
g++ -mavx2 -arch x86_64 -finline-functions -Wall -std=c++20 -pie -DSIMDJSON_DISABLE_DEPRECATED_API -O3 -DNDEBUG -fPIC -I/Users/lpgauth/Erlang/26.0-rc3/erts-14.0/include -I/Users/lpgauth/Erlang/26.0-rc3/lib/erl_interface-5.4/include  -c -o /Users/lpgauth/Git/simdjsone/c_src/simdjson.o /Users/lpgauth/Git/simdjsone/c_src/simdjson.cpp
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
g++ -mavx2 -arch x86_64 -finline-functions -Wall -std=c++20 -pie -DSIMDJSON_DISABLE_DEPRECATED_API -O3 -DNDEBUG -fPIC -I/Users/lpgauth/Erlang/26.0-rc3/erts-14.0/include -I/Users/lpgauth/Erlang/26.0-rc3/lib/erl_interface-5.4/include  -c -o /Users/lpgauth/Git/simdjsone/c_src/simdjson_nif.o /Users/lpgauth/Git/simdjsone/c_src/simdjson_nif.cpp
clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
/Users/lpgauth/Git/simdjsone/c_src/simdjson_nif.cpp:83:68: error: conversion from 'const dom::element' to 'long' is ambiguous
    case dom::element_type::INT64:      return enif_make_long(env, elm);
                                                                   ^~~
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5574:10: note: candidate function
  inline operator bool() const noexcept(false);
         ^
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5607:10: note: candidate function
  inline operator uint64_t() const noexcept(false);
         ^
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5615:10: note: candidate function
  inline operator int64_t() const noexcept(false);
         ^
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5623:10: note: candidate function
  inline operator double() const noexcept(false);
         ^
/Users/lpgauth/Erlang/26.0-rc3/erts-14.0/include/erl_nif_api_funcs.h:106:69: note: passing argument to parameter 'i' here
ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM,enif_make_long,(ErlNifEnv*, long i));
                                                                    ^
/Users/lpgauth/Git/simdjsone/c_src/simdjson_nif.cpp:84:69: error: conversion from 'const dom::element' to 'unsigned long' is ambiguous
    case dom::element_type::UINT64:     return enif_make_ulong(env, elm);
                                                                    ^~~
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5574:10: note: candidate function
  inline operator bool() const noexcept(false);
         ^
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5607:10: note: candidate function
  inline operator uint64_t() const noexcept(false);
         ^
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5615:10: note: candidate function
  inline operator int64_t() const noexcept(false);
         ^
/Users/lpgauth/Git/simdjsone/c_src/simdjson.h:5623:10: note: candidate function
  inline operator double() const noexcept(false);
         ^
/Users/lpgauth/Erlang/26.0-rc3/erts-14.0/include/erl_nif_api_funcs.h:53:83: note: passing argument to parameter 'i' here
ERL_NIF_API_FUNC_DECL(ERL_NIF_TERM,enif_make_ulong,(ErlNifEnv* env, unsigned long i));
                                                                                  ^
2 errors generated.
make[1]: *** [/Users/lpgauth/Git/simdjsone/c_src/simdjson_nif.o] Error 1
===> Hook for compile failed!

make: *** [compile] Error 1
```

```
clang -v
Homebrew clang version 16.0.0
Target: arm64-apple-darwin22.4.0
Thread model: posix
InstalledDir: /opt/homebrew/opt/llvm/bin
```