### PR TITLE
Fix flags for Darwin arm64

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -29,8 +29,8 @@ ifeq ($(UNAME_SYS), Linux)
 	CXXFLAGS ?= -mavx2 -finline-functions -Wall -std=c++20 
 else ifeq ($(UNAME_SYS), Darwin)
 	CXX = g++
-	CXXFLAGS ?= -mavx2 -arch x86_64 -finline-functions -Wall -std=c++20 -pie
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CXXFLAGS ?= -finline-functions -Wall -std=c++20 -pie
+	LDFLAGS ?= -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CXX = g++
 	CXXFLAGS ?= -mavx2 -finline-functions -Wall -std=c++20


### PR DESCRIPTION
According to the `simdjson` documentation, you don't need to specify the architecture flags. This fixes the build for Apple M1/M2 architecture.

```
The simdjson library automatically sets header flags for each implementation as it compiles; there is no need to set architecture-specific flags yourself (e.g., -mavx2, /AVX2 or -march=haswell), and it may even break runtime dispatch and your binaries will fail to run on older processors.
```
From https://simdjson.org/api/0.4.0/md_doc_implementation-selection.html